### PR TITLE
changed 'type return' to 'press any key' for easier menu navigation

### DIFF
--- a/GiftTrackerProject/GiftTracker/Program.cs
+++ b/GiftTrackerProject/GiftTracker/Program.cs
@@ -48,22 +48,21 @@ class Program
                 } // end if
 
                 else {
-                    string command; 
-                    string fileContents = File.ReadAllText("gifttracker-data.txt");
                     // Load data from filePath
-                    do {
-                        Console.Clear();
-                        Console.WriteLine("Loading data from file...");
-                        // Check length of data file and display file empty if no contents
-                        if(fileContents.Length < 1) {
-                            Console.WriteLine("\nData file is currently empty.\nReturn to menu to add new records.");
-                        } // end if
+                    string fileContents = File.ReadAllText("gifttracker-data.txt");
+                    Console.Clear();
+                    Console.WriteLine("Loading data from file...");
+                    // Check length of data file and display file empty if no contents
+                    if(fileContents.Length < 1) {
+                        Console.WriteLine("\nData file is currently empty.\nReturn to menu to add new records.");
+                    } // end if
 
+                    if(fileContents.Length > 1) {
                         Console.WriteLine($"\n{fileContents}");
+                    }
 
-                        Console.WriteLine("Enter 'return' to return to menu:");
-                        command = Console.ReadLine()!.ToLower();
-                    } while(command != "return");
+                    Console.WriteLine("Press any key to return to menu:");
+                    Console.ReadKey();
                 } // end else
 
 
@@ -142,10 +141,10 @@ class Program
                         break;
                     }
                     
-                    Console.WriteLine("\nEnter 'return' to return to menu or 'new' to add another new record: ");
+                    Console.WriteLine("\nEnter 'menu' to return to menu or 'new' to add another new record: ");
                     command = Console.ReadLine()!.ToLower();
 
-                } while(command != "return");
+                } while(command != "menu");
 
             } // record data loop
 

--- a/GiftTrackerProject/GiftTracker/gifttracker-data.txt
+++ b/GiftTrackerProject/GiftTracker/gifttracker-data.txt
@@ -19,3 +19,17 @@ Vendor:
 Vendor URL: 
 Price Range: 
 
+Name: Eric Robinson
+Birthday: 12-11-1971
+Gift Idea: Graph theory books
+Vendor: Amazon
+Vendor URL: amazon.com
+Price Range: 100
+
+Name: Eric Robinson
+Birthday: 12-11-1971
+Gift Idea: 
+Vendor: 
+Vendor URL: 
+Price Range: 
+


### PR DESCRIPTION
For view record display and record entry display, changed "type 'return' to return to menu" prompt to "press any key to return"
- users found 'type return' to be confusing and would just hit enter/return