### PR TITLE
updated 'press any key' feature to include datafile creation

### DIFF
--- a/GiftTrackerProject/GiftTracker/Program.cs
+++ b/GiftTrackerProject/GiftTracker/Program.cs
@@ -37,14 +37,8 @@ class Program
                     File.WriteAllText(filePath, "");
                     Console.WriteLine("\nNew datafile created.\nPlease return to menu to enter add records.");
 
-                    string main_menu;
-                    // Load data from filePath
-                    do
-                    {
-                        Console.WriteLine("\nEnter 'return' to return to menu:");
-                        main_menu = Console.ReadLine()!;
-                        main_menu.ToLower();
-                    } while (main_menu != "return");
+                    Console.WriteLine("\nPress any key to return to menu:");
+                    Console.ReadKey();
                 } // end if
 
                 else {
@@ -61,7 +55,7 @@ class Program
                         Console.WriteLine($"\n{fileContents}");
                     }
 
-                    Console.WriteLine("Press any key to return to menu:");
+                    Console.WriteLine("\nPress any key to return to menu:");
                     Console.ReadKey();
                 } // end else
 

--- a/GiftTrackerProject/GiftTracker/gifttracker-data.txt
+++ b/GiftTrackerProject/GiftTracker/gifttracker-data.txt
@@ -1,33 +1,5 @@
-Name: Emily Lopez
-Birthday: 21-05-1982
-Gift Idea: Wedding ring
-Vendor: Zales
-Vendor URL: zales.com
-Price Range: $25.00
-
-Name: Eric Robinson
+Name: Eric 
 Birthday: 
-Gift Idea: 
-Vendor: 
-Vendor URL: 
-Price Range: 
-
-Name: Eric Robinson
-Birthday: 12-12-19071
-Gift Idea: 
-Vendor: 
-Vendor URL: 
-Price Range: 
-
-Name: Eric Robinson
-Birthday: 12-11-1971
-Gift Idea: Graph theory books
-Vendor: Amazon
-Vendor URL: amazon.com
-Price Range: 100
-
-Name: Eric Robinson
-Birthday: 12-11-1971
 Gift Idea: 
 Vendor: 
 Vendor URL: 


### PR DESCRIPTION
Changed prompt of "Enter 'return' to return to menu" to "Press any key to continue" to address user feedback. 
This was changed earlier for most navigation, but the old method was still present in display for new datafile creation when no datafile is present. 